### PR TITLE
Remove optional keyword in favor of default: nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+* **Breaking change:** Remove `optional` setting. To update find all `optional: true` and change to `default: nil` instead.
+
 ## 0.6.0 - 2020-08-10
 
 * Return keyword name from `keyword`, allowing usage such as `private keyword :foo`. [[commit]](https://github.com/scottscheapflights/portrayal/commit/9e9db2cafc7eae14789c5b84f70efd18898ace76)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ class Person < MySuperClass
   extend Portrayal
 
   keyword :name
-  keyword :age, optional: true
+  keyword :age, default: nil
   keyword :favorite_fruit, default: 'feijoa'
 
   keyword :address do
@@ -172,7 +172,7 @@ class Address < ApplicationStruct
   keyword :street
   keyword :city
   keyword :postcode
-  keyword :country, optional: true
+  keyword :country, default: nil
 end
 ```
 
@@ -254,7 +254,7 @@ Address.portrayal.attributes(address) # => {street: '34th st', city: 'NYC', post
 Get everything portrayal knows about your keywords in one hash.
 
 ```ruby
-Address.portrayal.schema # => {:street=>{:optional=>false, :default=>nil}, :city=>{:optional=>false, :default=>nil}, :postcode=>{:optional=>false, :default=>nil}, :country=>{:optional=>true, :default=>[:return, nil]}}
+Address.portrayal.schema # => {:street=>nil, :city=>nil, :postcode=>nil, :country=><Portrayal::Default @value=nil @callable=false>}
 ```
 
 ## Philosophy
@@ -288,7 +288,7 @@ class Address < ApplicationStruct
   keyword :street
   keyword :city
   keyword :postcode
-  keyword :country, optional: true
+  keyword :country, default: nil
 end
 ```
 
@@ -331,7 +331,7 @@ class Address < ApplicationStruct
   keyword :street
   keyword :city
   keyword :postcode
-  keyword :country, optional: true
+  keyword :country, default: nil
 end
 ```
 

--- a/lib/portrayal.rb
+++ b/lib/portrayal.rb
@@ -4,7 +4,7 @@ require 'portrayal/schema'
 module Portrayal
   NULL = :_portrayal_value_not_set
 
-  def keyword(name, optional: NULL, default: NULL, define: nil, &block)
+  def keyword(name, default: NULL, define: nil, &block)
     unless respond_to?(:portrayal)
       class << self
         attr_reader :portrayal
@@ -14,13 +14,13 @@ module Portrayal
       end
 
       @portrayal = Schema.new
-      class_eval(portrayal.definition_of_object_enhancements)
+      class_eval(Schema::DEFINITION_OF_OBJECT_ENHANCEMENTS)
     end
 
     attr_accessor name
     protected "#{name}="
 
-    portrayal.add_keyword(name, optional, default)
+    portrayal.add_keyword(name, default)
     class_eval(portrayal.definition_of_initialize)
 
     if block_given?

--- a/lib/portrayal/default.rb
+++ b/lib/portrayal/default.rb
@@ -1,0 +1,13 @@
+module Portrayal
+  class Default
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+      @callable = value.is_a?(Proc) && !value.lambda?
+    end
+
+    def call?; @callable end
+    def initialize_dup(src); super; @value = src.value.dup end
+  end
+end

--- a/lib/portrayal/schema.rb
+++ b/lib/portrayal/schema.rb
@@ -1,59 +1,10 @@
+require 'portrayal/default'
+
 module Portrayal
   class Schema
     attr_reader :schema
 
-    def initialize; @schema = {}  end
-    def keywords;   @schema.keys  end
-    def [](name);   @schema[name] end
-
-    def attributes(object)
-      Hash[object.class.portrayal.keywords.map { |k| [k, object.send(k)] }]
-    end
-
-    def camelize(string); string.to_s.gsub(/(?:^|_+)([^_])/) { $1.upcase } end
-
-    def add_keyword(name, optional, default)
-      optional, default =
-        case [optional == NULL, default == NULL]
-        when [true,  true];  [false, nil]
-        when [false, true];  [optional, optional ? [:return, nil] : nil]
-        when [true,  false]; [true, [default_strategy(default), default]]
-        else; [optional, optional ? [default_strategy(default), default] : nil]
-        end
-
-      @schema[name.to_sym] = { optional: optional, default: default }
-    end
-
-    def get_default(name)
-      action, value = @schema[name][:default]
-      action == :call ? value.call : value
-    end
-
-    def default_strategy(value)
-      (value.is_a?(Proc) && !value.lambda?) ? :call : :return
-    end
-
-    def initialize_dup(other)
-      super
-      @schema =
-        other.schema.map { |k, v|
-          default = v[:default] ? v[:default].map(&:dup) : v[:default]
-          [k, { optional: v[:optional], default: default }]
-        }.to_h
-    end
-
-    def definition_of_initialize
-      init_args = @schema.map { |name, config|
-        config[:optional] ?
-          "#{name}: self.class.portrayal.get_default(:#{name})" : "#{name}:"
-      }.join(',')
-
-      init_assigns = @schema.keys.map { |name| "@#{name} = #{name}" }.join('; ')
-      "def initialize(#{init_args}); #{init_assigns} end"
-    end
-
-    def definition_of_object_enhancements
-      <<-RUBY
+    DEFINITION_OF_OBJECT_ENHANCEMENTS = <<~RUBY.freeze
       def eql?(other); self.class == other.class && self == other end
       def hash; [self.class, self.class.portrayal.attributes(self)].hash end
 
@@ -71,18 +22,49 @@ module Portrayal
 
       def initialize_dup(source)
         self.class.portrayal.attributes(source).each do |key, value|
-          instance_variable_set('@' + key.to_s, value.dup)
+          instance_variable_set("@\#{key}", value.dup)
         end
         super
       end
 
       def initialize_clone(source)
         self.class.portrayal.attributes(source).each do |key, value|
-          instance_variable_set('@' + key.to_s, value.clone)
+          instance_variable_set("@\#{key}", value.clone)
         end
         super
       end
-      RUBY
+    RUBY
+
+    def initialize; @schema = {}  end
+    def keywords;   @schema.keys  end
+    def [](name);   @schema[name] end
+
+    def attributes(object)
+      Hash[object.class.portrayal.keywords.map { |k| [k, object.send(k)] }]
+    end
+
+    def camelize(string); string.to_s.gsub(/(?:^|_+)([^_])/) { $1.upcase } end
+
+    def add_keyword(name, default)
+      @schema[name.to_sym] = default.equal?(NULL) ? nil : Default.new(default)
+    end
+
+    def initialize_dup(other)
+      super; @schema = other.schema.transform_values(&:dup)
+    end
+
+    def definition_of_initialize
+      init_args = @schema.map { |name, default|
+        "#{name}:#{default && " self.class.portrayal[:#{name}]"}"
+      }.join(', ')
+
+      init_assigns = @schema.keys.map { |name|
+        "@#{name} = #{name}.is_a?(Portrayal::Default) ? " \
+          "(#{name}.call? ? #{name}.value.call : #{name}.value) : " \
+          "#{name}"
+      }.join('; ')
+
+      "def initialize(#{init_args}); #{init_assigns} end"
     end
   end
 end


### PR DESCRIPTION
Instead of writing 

```ruby
keyword :foo, optional: true
```

this change removes `optional` in favor of writing a shorter

```ruby
keyword :foo, default: nil
```

This has exactly the same effect, but simplifies internals, and reveals what `optional` actually implies.

What do ya'll think?

P.S. I made another PR on top of this one, but I could do the other change without making this change if we decided against it.