### PR TITLE
Execute default procs in initialize context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * **Breaking change:** Remove `optional` setting. To update find all `optional: true` and change to `default: nil` instead.
 
+* **Breaking change:** Move `self` of default procs to `initialize` context. Before this change, default procs used to be executed naively in class context. Now they can access other keyword readers and instance methods since their `self` is now coming from `initialize`. To update, look through your default procs and replace any reference to current class's methods such as `method_name` with `self.class.method_name`.
+
 ## 0.6.0 - 2020-08-10
 
 * Return keyword name from `keyword`, allowing usage such as `private keyword :foo`. [[commit]](https://github.com/scottscheapflights/portrayal/commit/9e9db2cafc7eae14789c5b84f70efd18898ace76)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,41 @@ Any other value works as normal.
 keyword :foo, default: 4
 ```
 
+#### Default procs
+
+Default procs are executed as though they were called in your class's `initialize`, so they have access to other keywords and instance methods.
+
+```ruby
+keyword :name
+keyword :greeting, default: proc { "Hello, #{name}" }
+```
+
+Defaults can also use results of other defaults.
+
+```ruby
+keyword :four,  default: proc { 2 + 2 }
+keyword :eight, default: proc { four * 2 }
+```
+
+Or instance methods of the class.
+
+```ruby
+keyword :id, default: proc { generate_id }
+
+private
+
+def generate_id
+  SecureRandom.alphanumeric
+end
+```
+
+Note: The order in which you declare keywords matters when specifying defaults that depend on other keywords. This will not have the desired effect:
+
+```ruby
+keyword :greeting, default: proc { "Hello, #{name}" }
+keyword :name
+```
+
 ### Nested Classes
 
 When you pass a block to a keyword, it creates a nested class named after camelized keyword name.

--- a/lib/portrayal/schema.rb
+++ b/lib/portrayal/schema.rb
@@ -59,8 +59,8 @@ module Portrayal
       }.join(', ')
 
       init_assigns = @schema.keys.map { |name|
-        "@#{name} = #{name}.is_a?(Portrayal::Default) ? " \
-          "(#{name}.call? ? #{name}.value.call : #{name}.value) : " \
+        "@#{name} = #{name}.is_a?(::Portrayal::Default) ? " \
+          "(#{name}.call? ? instance_exec(&#{name}.value) : #{name}.value) : " \
           "#{name}"
       }.join('; ')
 

--- a/spec/portrayal_spec.rb
+++ b/spec/portrayal_spec.rb
@@ -91,6 +91,34 @@ RSpec.describe Portrayal do
       expect(target.new.foo).to eq(4)
     end
 
+    it 'provides access to peer keywords when executing proc defaults' do
+      target.keyword :foo
+      target.keyword :bar, default: proc { "#{foo} world" }
+      expect(target.new(foo: 'hello').bar).to eq('hello world')
+    end
+
+    it 'provides access to peer defaults when executing proc defaults' do
+      target.keyword :foo, default: proc { 2 + 2 }
+      target.keyword :bar, default: proc { foo * 2 }
+      expect(target.new.bar).to eq(8)
+    end
+
+    it 'provides access to instance methods when executing proc defaults' do
+      TEST_CLASS__ = target
+      class TEST_CLASS__
+        keyword :foo, default: proc { hello_world }
+
+        private
+
+        def hello_world
+          'Hello, World!'
+        end
+      end
+
+      expect(target.new.foo).to eq('Hello, World!')
+      Object.send :remove_const, :TEST_CLASS__
+    end
+
     it 'sets lambda defaults without calling them' do
       target.keyword :foo, default: -> { 2 + 2 }
       expect(target.new.foo).to_not eq(4)


### PR DESCRIPTION
Before this change you couldn't do this.

```ruby
class Person
  extend Portrayal

  keyword :name
  keyword :greeting, default: proc { "Hello, #{name}" } # <- couldn't reference another keyword
  keyword :id,       default: proc { generate_id }      # <- couldn't call instance method

  private

  def generate_id
    SecureRandom.alphanumeric
  end
end
```

Now you can, because procs are now executed in the scope of `initialize` instead of where they're declared. This makes defaults a lot more versatile.

What do ya'll think?