### PR TITLE
Fix default procs' behavior when overriding keywords in subclasses

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,24 +1,18 @@
 name: RSpec
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
 
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: gem install bundler
-      - run: bundle install
+          bundler-cache: true
       - run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -263,6 +263,50 @@ end
 
 This defines `Person::Country`, while the accessor remains `visited_countries`.
 
+### Subclassing
+
+Portrayal supports subclassing.
+
+```ruby
+class Person
+  extend Portrayal
+  
+  class << self
+    def from_contact(contact)
+      new name:    contact.full_name,
+          address: contact.address.to_s,
+          email:   contact.email
+    end
+  end
+  
+  keyword :name
+  keyword :address
+  keyword :email, default: nil
+end
+```
+
+```ruby
+class Employee < Person
+  keyword :employee_id
+  keyword :email, default: proc { "#{employee_id}@example.com" }
+end
+```
+
+Now when you call `Employee.new` it will accept keywords of both superclass and subclass. You can also see how `email`'s default is overridden in the subclass.
+
+However, if you try calling `Employee.from_contact(contact)` it will error out, because that constructor doesn't set an `employee_id` required in the subclass. You can remedy that with a small change.
+
+```ruby
+    def from_contact(contact, **kwargs)
+      new name:    contact.full_name,
+          address: contact.address.to_s,
+          email:   contact.email,
+          **kwargs
+    end
+```
+
+If you add `**kwargs` to `Person.from_contact` and pass them through to new, then you are now able to call `Employee.from_contact(contact, employee_id: 'some_id')`
+
 ### Schema
 
 Every class that has at least one keyword defined in it automatically receives a class method called `portrayal`. This method is a schema of your object with some additional helpers.

--- a/lib/portrayal/schema.rb
+++ b/lib/portrayal/schema.rb
@@ -46,7 +46,9 @@ module Portrayal
     def camelize(string); string.to_s.gsub(/(?:^|_+)([^_])/) { $1.upcase } end
 
     def add_keyword(name, default)
-      @schema[name.to_sym] = default.equal?(NULL) ? nil : Default.new(default)
+      name = name.to_sym
+      @schema.delete(name) # Forcing keyword to be added at the end of the hash.
+      @schema[name] = default.equal?(NULL) ? nil : Default.new(default)
     end
 
     def initialize_dup(other)

--- a/spec/portrayal_spec.rb
+++ b/spec/portrayal_spec.rb
@@ -219,6 +219,13 @@ RSpec.describe Portrayal do
       value = target.keyword :foo
       expect(value).to eq(:foo)
     end
+
+    it 're-appends keyword to the end of schema on every redeclaration' do
+      target.keyword :foo
+      target.keyword :bar
+      target.keyword :foo, default: proc { bar }
+      expect(target.new(bar: 'bar').foo).to eq('bar')
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
Portrayal relies on an ordered ruby hash to initialize keywords in the correct order. However, if overriding the same keyword in a subclass (by declaring it again), it didn't move keyword to the bottom of the hash, so this would happen:

```ruby
class Person
  extend Portrayal
  keyword :email, default: nil
end

class Employee < Person
  keyword :employee_id
  keyword :email, default: proc { "#{employee_id}@example.com" }
end

employee = Employee.new(employee_id: '1234')
employee.email # => "@example.com"
```

The email is broken because it relies on having employee_id declared before email, but email was already declared first in the superclass. This change fixes situations like this by re-adding the keyword to the bottom of the hash on every re-declaration.

Additional commits in here:

- Update github rspec workflow with Ruby 3, and non-deprecated action
- Add readme section for subclassing